### PR TITLE
Potential fix for code scanning alert no. 3: URL redirection from remote source

### DIFF
--- a/vuln_manager/views.py
+++ b/vuln_manager/views.py
@@ -13,6 +13,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import User
+from django.utils.http import url_has_allowed_host_and_scheme
 import json
 import os
 
@@ -28,6 +29,12 @@ CRITICALITY_WEIGHTS = {
 
 def login_view(request):
     next_url = request.GET.get("next", "dashboard")
+    if not url_has_allowed_host_and_scheme(
+        url=next_url,
+        allowed_hosts={request.get_host()},
+        require_https=request.is_secure(),
+    ):
+        next_url = "dashboard"
     if request.user.is_authenticated:
         return redirect(next_url)
     if request.method == "POST":

--- a/vuln_manager/views.py
+++ b/vuln_manager/views.py
@@ -324,7 +324,6 @@ def software_form(request, pk=None):
 
         if host_ids:
             sw.hosts.set(host_ids)
-            # Propagate criticality
             for host in sw.hosts.all():
                 recalculate_host_criticality(host)
         else:
@@ -505,7 +504,14 @@ def update_vuln_status(request, pk):
         if new_status in dict(Vulnerability.STATUS_CHOICES):
             vuln.status = new_status
             vuln.save()
-    return redirect(request.META.get("HTTP_REFERER", "kanban_board"))
+        referer = request.META.get("HTTP_REFERER")
+        if referer and url_has_allowed_host_and_scheme(
+            url=referer,
+            allowed_hosts={request.get_host()},
+            require_https=request.is_secure(),
+        ):
+            return redirect("referer")
+    return redirect("kanban_board")
 
 
 @login_required


### PR DESCRIPTION
Potential fix for [https://github.com/MichaelHeu4/CVE3PO/security/code-scanning/3](https://github.com/MichaelHeu4/CVE3PO/security/code-scanning/3)

Use Django’s built-in URL safety check before redirecting to `next_url`. The best fix is to validate `next_url` with `url_has_allowed_host_and_scheme`, allowing only same-host (or explicitly trusted hosts) URLs over the current request scheme, and fallback to a safe internal route (`"dashboard"`) if invalid.

In `vuln_manager/views.py`:
- Add import: `from django.utils.http import url_has_allowed_host_and_scheme`.
- In `login_view`, after reading `next_url`, validate it using:
  - `allowed_hosts={request.get_host()}`
  - `require_https=request.is_secure()`
- If invalid, overwrite `next_url = "dashboard"`.

This preserves existing behavior for legitimate internal redirects while blocking attacker-supplied external redirects.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
